### PR TITLE
feat: add putAllContext method

### DIFF
--- a/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
@@ -5,9 +5,6 @@ import com.spotify.confidence.Confidence
 import com.spotify.confidence.ConfidenceFactory
 import com.spotify.confidence.ConfidenceValue
 import com.spotify.confidence.FlagResolution
-import com.spotify.confidence.cache.DiskStorage
-import com.spotify.confidence.client.ConfidenceValueMap
-import com.spotify.confidence.client.ResolveFlags
 import com.spotify.confidence.client.SdkMetadata
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -109,6 +106,12 @@ class ConfidenceFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
         val key = call.argument<String>("key")!!
         val value = call.argument<Map<String, Any>>("value")!!.convert()
         confidence.putContext(key, value)
+        result.success(null)
+      }
+      "putAllContext" -> {
+        val wrappedContext = call.argument<Map<String, Map<String, Any>>>("context")!!
+        val context: Map<String, ConfidenceValue> = wrappedContext.mapValues { (_, value) -> value.convert() }
+        confidence.putContext(context)
         result.success(null)
       }
       "track" -> {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,14 @@ class _MyAppState extends State<MyApp> {
     try {
       await dotenv.load(fileName: ".env");
       await _confidenceFlutterSdkPlugin.setup(dotenv.env["API_KEY"]!);
-      await _confidenceFlutterSdkPlugin.putContext("targeting_key", "random");
+      await _confidenceFlutterSdkPlugin.putAllContext({
+        "targeting_key": "random",
+        "my_bool": false,
+        "my_int": 1,
+        "my_double": 1.1,
+        "my_map": {"key": "value"},
+        "my_list": ["value1", "value2"]
+      });
       await _confidenceFlutterSdkPlugin.fetchAndActivate();
       object =
       (_confidenceFlutterSdkPlugin.getObject("hawkflag", <String, dynamic>{})).toString();

--- a/ios/Classes/ConfidenceFlutterSdkPlugin.swift
+++ b/ios/Classes/ConfidenceFlutterSdkPlugin.swift
@@ -79,6 +79,19 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
             confidence?.putContext(key: key, value: value)
             result("")
             break;
+        case "putAllContext":
+            guard let args = call.arguments as? Dictionary<String, Dictionary<String, Any>> else {
+                result("")
+                return
+            }
+            let context = args["context"] as! Dictionary<String, Dictionary<String, Any>>
+            let map: ConfidenceStruct = context.mapValues { wrappedValue in
+                let type = wrappedValue["type"] as! String
+                return convertValue(type, wrappedValue["value"]!)
+            }
+            confidence?.putContext(context: map)
+            result("")
+            break;
         case "track":
             guard let args = call.arguments as? Dictionary<String, Any> else {
                 return

--- a/lib/confidence_flutter_sdk.dart
+++ b/lib/confidence_flutter_sdk.dart
@@ -16,6 +16,13 @@ class ConfidenceFlutterSdk {
     }
   }
 
+  Future<void> putAllContext(Map<String, dynamic> context) async {
+    await ConfidenceFlutterSdkPlatform.instance.putAllContext(context);
+    if(isInitialized) {
+      await fetchAndActivate();
+    }
+  }
+
   void track(String eventName, Map<String, dynamic> data) {
     ConfidenceFlutterSdkPlatform.instance.track(eventName, data);
   }

--- a/lib/confidence_flutter_sdk_method_channel.dart
+++ b/lib/confidence_flutter_sdk_method_channel.dart
@@ -36,6 +36,18 @@ class MethodChannelConfidenceFlutterSdk extends ConfidenceFlutterSdkPlatform {
   }
 
   @override
+  Future<void> putAllContext(Map<String, dynamic> context) async {
+    final wrappedContext = context.map((key, value) {
+      return MapEntry(key, toTypedValue(value));
+    });
+    await methodChannel
+        .invokeMethod<void>(
+        'putAllContext',
+        {'context': wrappedContext}
+    );
+  }
+
+  @override
   void track(String eventName, Map<String, dynamic> data) {
     final wrappedData = data.map((key, value) {
       return MapEntry(key, toTypedValue(value));

--- a/lib/confidence_flutter_sdk_platform_interface.dart
+++ b/lib/confidence_flutter_sdk_platform_interface.dart
@@ -43,6 +43,10 @@ abstract class ConfidenceFlutterSdkPlatform extends PlatformInterface {
     throw UnimplementedError('putContext() has not been implemented.');
   }
 
+  Future<void> putAllContext(Map<String, dynamic> context) async {
+    throw UnimplementedError('putAllContext() has not been implemented.');
+  }
+
   Future<bool> isStorageEmpty() {
     throw UnimplementedError('isStorageEmpty() has not been implemented.');
   }


### PR DESCRIPTION
Adding a functionality to more than one single context in one go.
it's possible now to send a full map to the `putAllContext` to the confidence sdk.