### PR TITLE
feat: add lifecycle events

### DIFF
--- a/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
@@ -1,6 +1,8 @@
 package com.example.confidence_flutter_sdk
 
 import android.content.Context
+import androidx.lifecycle.LifecycleObserver
+import com.spotify.confidence.AndroidLifecycleEventProducer
 import com.spotify.confidence.Confidence
 import com.spotify.confidence.ConfidenceFactory
 import com.spotify.confidence.ConfidenceValue
@@ -29,6 +31,7 @@ class ConfidenceFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
   private lateinit var confidence: Confidence
   private val coroutineScope = CoroutineScope(Dispatchers.IO)
   private lateinit var context: Context
+  private lateinit var application: android.app.Application
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "confidence_flutter_sdk")
@@ -65,6 +68,14 @@ class ConfidenceFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
       "isStorageEmpty" -> {
         val isEmpty = confidence.isStorageEmpty()
         result.success(isEmpty)
+      }
+      "trackApplicationLifecycleState" -> {
+        confidence.track(
+          AndroidLifecycleEventProducer(
+            application = application,
+            trackActivities = true
+          ))
+        result.success(null)
       }
       "getString" -> {
         val key = call.argument<String>("key")!!
@@ -141,6 +152,7 @@ class ConfidenceFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     context = binding.activity.applicationContext
+    application = binding.activity.application
   }
 
   override fun onDetachedFromActivityForConfigChanges() {

--- a/ios/Classes/ConfidenceFlutterSdkPlugin.swift
+++ b/ios/Classes/ConfidenceFlutterSdkPlugin.swift
@@ -9,6 +9,7 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
     }
 
     var confidence: Confidence? = nil
+    var lifecycleProducer: ConfidenceAppLifecycleProducer? = nil
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
@@ -90,6 +91,15 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
                 return convertValue(type, wrappedValue["value"]!)
             }
             confidence?.putContext(context: map)
+        case "trackApplicationLifecycleState":
+            if(lifecycleProducer == nil) {
+                lifecycleProducer = ConfidenceAppLifecycleProducer()
+            }
+            guard let producer = lifecycleProducer else {
+                result("")
+                break;
+            }
+            confidence?.track(producer: producer)
             result("")
             break;
         case "track":

--- a/lib/confidence_flutter_sdk.dart
+++ b/lib/confidence_flutter_sdk.dart
@@ -108,4 +108,8 @@ class ConfidenceFlutterSdk {
     await ConfidenceFlutterSdkPlatform.instance.activateAndFetchAsync();
     await fillAllFlags();
   }
+
+  Future<void> trackApplicationLifecycleState() async {
+    await ConfidenceFlutterSdkPlatform.instance.trackApplicationLifecycleState();
+  }
 }

--- a/lib/confidence_flutter_sdk_method_channel.dart
+++ b/lib/confidence_flutter_sdk_method_channel.dart
@@ -21,6 +21,11 @@ class MethodChannelConfidenceFlutterSdk extends ConfidenceFlutterSdkPlatform {
   }
 
   @override
+  Future<void> trackApplicationLifecycleState() async {
+    return await methodChannel.invokeMethod<void>('trackApplicationLifecycleState');
+  }
+
+  @override
   Future<void> activateAndFetchAsync() async {
     return await methodChannel.invokeMethod<void>('activateAndFetchAsync');
   }

--- a/lib/confidence_flutter_sdk_platform_interface.dart
+++ b/lib/confidence_flutter_sdk_platform_interface.dart
@@ -23,6 +23,10 @@ abstract class ConfidenceFlutterSdkPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  Future<void> trackApplicationLifecycleState() async {
+    throw UnimplementedError('trackApplicationLifecycleState() has not been implemented.');
+  }
+
   Future<void> setup(String apiKey) {
     throw UnimplementedError('setup() has not been implemented.');
   }


### PR DESCRIPTION
Adding functionality to track the lifecycle events and the build name, app versions etc using confidence AppLifecycleProducers, [read more here](https://confidence.spotify.com/docs/events/quickstart#mobile-event-producers)