### PR TITLE
fix: fix the reflect version at 1.9.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,7 @@ android {
     dependencies {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
         implementation("com.spotify.confidence:confidence-sdk-android:0.3.2")
+        implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.0") // force this to 1.9.0
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.1.0")
     }


### PR DESCRIPTION
This is a quick fix that should hopefully fix deserialization issues/crashes that could occur when incompatible versions of the kotlinx serialization is used.