### PR TITLE
feat: add support for logging

### DIFF
--- a/.github/workflows/android-test.yaml
+++ b/.github/workflows/android-test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     env:
       FLUTTER_CHANNEL: stable
-      FLUTTER_VERSION: 3.22.2
+      FLUTTER_VERSION: 3.27.3
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     env:
       FLUTTER_CHANNEL: stable
-      FLUTTER_VERSION: 3.22.2
+      FLUTTER_VERSION: 3.27.3
 
     steps:
     - name: Checkout code
@@ -21,11 +21,12 @@ jobs:
     - name: fetch submodules
       run: git submodule update --init --recursive
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'zulu'
+
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:

--- a/.github/workflows/ios-test.yaml
+++ b/.github/workflows/ios-test.yaml
@@ -12,7 +12,7 @@ jobs:
 
     env:
       FLUTTER_CHANNEL: stable
-      FLUTTER_VERSION: 3.22.2
+      FLUTTER_VERSION: 3.27.3
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FLUTTER_CHANNEL: stable
-      FLUTTER_VERSION: 3.22.2
+      FLUTTER_VERSION: 3.27.3
     if: ${{ needs.release-please.outputs.release_created }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Do not remove or rename entries in this file, only add new ones
 # See https://github.com/flutter/flutter/issues/128635 for more context.
 
+example/.env
+
 # Miscellaneous
 *.class
 *.lock

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,7 +51,7 @@ android {
 
     dependencies {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-        implementation("com.spotify.confidence:confidence-sdk-android:0.3.2")
+        implementation("com.spotify.confidence:confidence-sdk-android:0.3.6")
         implementation("org.jetbrains.kotlin:kotlin-reflect:1.9.0") // force this to 1.9.0
         testImplementation("org.jetbrains.kotlin:kotlin-test")
         testImplementation("org.mockito:mockito-core:5.1.0")

--- a/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
+++ b/android/src/main/kotlin/com/example/confidence_flutter_sdk/ConfidenceFlutterSdkPlugin.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.spotify.confidence.Confidence
 import com.spotify.confidence.ConfidenceFactory
 import com.spotify.confidence.ConfidenceValue
+import com.spotify.confidence.LoggingLevel
 import com.spotify.confidence.FlagResolution
 import com.spotify.confidence.client.SdkMetadata
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -41,11 +42,12 @@ class ConfidenceFlutterSdkPlugin: FlutterPlugin, MethodCallHandler, ActivityAwar
         confidence.flush()
       }
       "setup" -> {
-        val apiKey = call.arguments as String
+        val apiKey = call.argument<String>("apiKey")!!
+        val loggingLevel = call.argument<String>("loggingLevel")!!
         confidence = ConfidenceFactory.create(
           context,
           apiKey,
-          sdk = SdkMetadata("SDK_ID_FLUTTER_ANDROID_CONFIDENCE", "0.0.1")
+          loggingLevel = LoggingLevel.valueOf(loggingLevel)
         )
         result.success(null)
       }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -48,6 +48,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.debug
+            shrinkResources = false
+            minifyEnabled = false
         }
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.1.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.0" apply false
 }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '17.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
     // We also handle the message potentially returning null.
     try {
       await dotenv.load(fileName: ".env");
-      await _confidenceFlutterSdkPlugin.setup(dotenv.env["API_KEY"]!);
+      await _confidenceFlutterSdkPlugin.setup(dotenv.env["API_KEY"]!, LoggingLevel.VERBOSE);
       await _confidenceFlutterSdkPlugin.putAllContext({
         "targeting_key": "random",
         "my_bool": false,

--- a/ios/Classes/ConfidenceFlutterSdkPlugin.swift
+++ b/ios/Classes/ConfidenceFlutterSdkPlugin.swift
@@ -41,7 +41,6 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
             let apiKey = args["apiKey"] as! String
             let logLevel = args["loggingLevel"] as! String
             self.confidence = Confidence.Builder(clientSecret: apiKey, loggerLevel: loggerLevel(from: logLevel))
-                .setLogLevel(logLevel)
                 .build()
             result("")
             break;
@@ -178,7 +177,7 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    func loggerLevel(from string: String) -> LoggerLevel? {
+    func loggerLevel(from string: String) -> LoggerLevel {
         switch string.uppercased() {
         case "VERBOSE":
             return .TRACE

--- a/ios/Classes/ConfidenceFlutterSdkPlugin.swift
+++ b/ios/Classes/ConfidenceFlutterSdkPlugin.swift
@@ -34,8 +34,14 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
             result(str)
             break;
         case "setup":
-            let apiKey = call.arguments as! String
-            self.confidence = Confidence.Builder(clientSecret: apiKey)
+            guard let args = call.arguments as? Dictionary<String, Any> else {
+                result("")
+                return
+            }
+            let apiKey = args["apiKey"] as! String
+            let logLevel = args["loggingLevel"] as! String
+            self.confidence = Confidence.Builder(clientSecret: apiKey, loggerLevel: loggerLevel(from: logLevel))
+                .setLogLevel(logLevel)
                 .build()
             result("")
             break;
@@ -63,7 +69,9 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
                     return
                 }
                 try! confidence.activate()
-                confidence.asyncFetch()
+                Task {
+                    await confidence.asyncFetch()
+                }
                 result("")
             }
             break;
@@ -167,6 +175,21 @@ public class ConfidenceFlutterSdkPlugin: NSObject, FlutterPlugin {
             break;
         default:
             result(FlutterMethodNotImplemented)
+        }
+    }
+
+    func loggerLevel(from string: String) -> LoggerLevel? {
+        switch string.uppercased() {
+        case "VERBOSE":
+            return .TRACE
+        case "DEBUG":
+            return .DEBUG
+        case "WARN":
+            return .WARN
+        case "ERROR":
+            return .ERROR
+        default:
+            return .WARN
         }
     }
 }

--- a/lib/confidence_flutter_sdk.dart
+++ b/lib/confidence_flutter_sdk.dart
@@ -90,8 +90,8 @@ class ConfidenceFlutterSdk {
     return resolveKey(key) ?? defaultValue;
   }
 
-  Future<void> setup(String apiKey) async {
-    return await ConfidenceFlutterSdkPlatform.instance.setup(apiKey);
+  Future<void> setup(String apiKey, [LoggingLevel loggingLevel = LoggingLevel.WARN]) async {
+    return await ConfidenceFlutterSdkPlatform.instance.setup(apiKey, loggingLevel);
   }
 
   Future<void> fetchAndActivate() async {
@@ -108,4 +108,12 @@ class ConfidenceFlutterSdk {
     await ConfidenceFlutterSdkPlatform.instance.activateAndFetchAsync();
     await fillAllFlags();
   }
+}
+
+enum LoggingLevel {
+  VERBOSE, // 0
+  DEBUG, // 1
+  WARN, // 2
+  ERROR, // 3
+  NONE // 4
 }

--- a/lib/confidence_flutter_sdk_method_channel.dart
+++ b/lib/confidence_flutter_sdk_method_channel.dart
@@ -1,3 +1,4 @@
+import 'package:confidence_flutter_sdk/confidence_flutter_sdk.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'dart:convert';
@@ -11,8 +12,8 @@ class MethodChannelConfidenceFlutterSdk extends ConfidenceFlutterSdkPlatform {
   final methodChannel = const MethodChannel('confidence_flutter_sdk');
 
   @override
-  Future<void> setup(String apiKey) async {
-    return await methodChannel.invokeMethod<void>('setup', apiKey);
+  Future<void> setup(String apiKey, LoggingLevel loggingLevel) async {
+    return await methodChannel.invokeMethod<void>('setup', {'apiKey': apiKey, 'loggingLevel': loggingLevel.name});
   }
 
   @override

--- a/lib/confidence_flutter_sdk_platform_interface.dart
+++ b/lib/confidence_flutter_sdk_platform_interface.dart
@@ -1,3 +1,4 @@
+import 'package:confidence_flutter_sdk/confidence_flutter_sdk.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'confidence_flutter_sdk_method_channel.dart';
@@ -23,7 +24,7 @@ abstract class ConfidenceFlutterSdkPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> setup(String apiKey) {
+  Future<void> setup(String apiKey, LoggingLevel loggingLevel) {
     throw UnimplementedError('setup() has not been implemented.');
   }
 


### PR DESCRIPTION
Adding the `LoggingLevel` enum to control how much logging comes from the underlying SDKs.

"Unfortunately" I had already updated my flutter tooling which caused me to have to add a bunch of other changes :(

I am unsure if the fact that we are bumping flutter version we build with would make this a breaking change.