### PR TITLE
docs: clean up changelog for future releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,106 +5,35 @@
 
 ### 🐛 Bug Fixes
 
-* **ci:** Add copy removal of sub module ([#12](https://github.com/spotify/confidence-sdk-flutter/issues/12)) ([a756da2](https://github.com/spotify/confidence-sdk-flutter/commit/a756da2c5da4a85deb3f26d3813d50e7bda7a020))
-* **ci:** Fix pub warnings ([#15](https://github.com/spotify/confidence-sdk-flutter/issues/15)) ([3d9194c](https://github.com/spotify/confidence-sdk-flutter/commit/3d9194c4d9f059d9803ad4f690b8bf6653600d40))
-* Current version is 0.0.3 in pub.dev ([#10](https://github.com/spotify/confidence-sdk-flutter/issues/10)) ([963f707](https://github.com/spotify/confidence-sdk-flutter/commit/963f7077ef825284359f03bcea63c849de214083))
-* **doc:** add readme text for putContext and putAllContext ([#28](https://github.com/spotify/confidence-sdk-flutter/issues/28)) ([cec61c4](https://github.com/spotify/confidence-sdk-flutter/commit/cec61c4a396e6c15a3494c0166735ebd5f13ae4f))
 * fix the reflect version at 1.9.0 ([#30](https://github.com/spotify/confidence-sdk-flutter/issues/30)) ([401004f](https://github.com/spotify/confidence-sdk-flutter/commit/401004f0beaa4e1d09e3e57be6dd0f045bd0975a))
 
-
-### ✨ New Features
-
-* Add flush method ([#19](https://github.com/spotify/confidence-sdk-flutter/issues/19)) ([0299534](https://github.com/spotify/confidence-sdk-flutter/commit/02995341c06e0d5e2343857da6394511d6c26b88))
-* Add non blocking way of getting values ([#24](https://github.com/spotify/confidence-sdk-flutter/issues/24)) ([8b1a163](https://github.com/spotify/confidence-sdk-flutter/commit/8b1a1639c4a66ed2dd33854ff61638f693484df5))
-* add putAllContext method ([#26](https://github.com/spotify/confidence-sdk-flutter/issues/26)) ([7540810](https://github.com/spotify/confidence-sdk-flutter/commit/7540810ee5bfeb5284544e6f3313f87eccd52393))
-
-
-### 🧹 Chore
-
-* **main:** release 0.0.4 ([#11](https://github.com/spotify/confidence-sdk-flutter/issues/11)) ([04a7e32](https://github.com/spotify/confidence-sdk-flutter/commit/04a7e328101165ffd4cee04ffe20853d3db4865a))
-* **main:** release 0.0.4 ([#13](https://github.com/spotify/confidence-sdk-flutter/issues/13)) ([7b23d2e](https://github.com/spotify/confidence-sdk-flutter/commit/7b23d2e8f1008322e3e3ba4b54118ed063aaf37d))
-* **main:** release 0.0.4 ([#16](https://github.com/spotify/confidence-sdk-flutter/issues/16)) ([43b4423](https://github.com/spotify/confidence-sdk-flutter/commit/43b4423e88aeb7869c50b2ef3e6155958475004c))
-* **main:** release 0.0.5 ([#17](https://github.com/spotify/confidence-sdk-flutter/issues/17)) ([ad7e91f](https://github.com/spotify/confidence-sdk-flutter/commit/ad7e91f4bbbd55666caca8d0870828ebe6aca986))
-* **main:** release 0.0.6 ([#23](https://github.com/spotify/confidence-sdk-flutter/issues/23)) ([61ac22d](https://github.com/spotify/confidence-sdk-flutter/commit/61ac22deee5fcb27b5a445d04dd81bab1147025d))
-* **main:** release 0.0.7 ([#25](https://github.com/spotify/confidence-sdk-flutter/issues/25)) ([885f46c](https://github.com/spotify/confidence-sdk-flutter/commit/885f46ccf7238da0ab764a63eb76126e680a6f15))
-
-
-### 📚 Documentation
-
-* Add running example app in xcode in readme ([#20](https://github.com/spotify/confidence-sdk-flutter/issues/20)) ([4d0142b](https://github.com/spotify/confidence-sdk-flutter/commit/4d0142b45e58a1f5bb5ae9771a1a40615916ab66))
-* minor corrections ([#18](https://github.com/spotify/confidence-sdk-flutter/issues/18)) ([e02c6d7](https://github.com/spotify/confidence-sdk-flutter/commit/e02c6d720d7c5bf6ece0bfcf39b7f5965aa7acde))
 
 ## [0.0.7](https://github.com/spotify/confidence-sdk-flutter/compare/0.0.6...0.0.7) (2025-01-13)
 
 
-### 🐛 Bug Fixes
-
-* **doc:** add readme text for putContext and putAllContext ([#28](https://github.com/spotify/confidence-sdk-flutter/issues/28)) ([cec61c4](https://github.com/spotify/confidence-sdk-flutter/commit/cec61c4a396e6c15a3494c0166735ebd5f13ae4f))
-
-
 ### ✨ New Features
 
 * add putAllContext method ([#26](https://github.com/spotify/confidence-sdk-flutter/issues/26)) ([7540810](https://github.com/spotify/confidence-sdk-flutter/commit/7540810ee5bfeb5284544e6f3313f87eccd52393))
 
-
-### 🧹 Chore
-
-
-
 ### 📚 Documentation
+
+* **doc:** add readme text for putContext and putAllContext ([#28](https://github.com/spotify/confidence-sdk-flutter/issues/28)) ([cec61c4](https://github.com/spotify/confidence-sdk-flutter/commit/cec61c4a396e6c15a3494c0166735ebd5f13ae4f))
 
 
 ## [0.0.6](https://github.com/spotify/confidence-sdk-flutter/compare/0.0.5...0.0.6) (2024-09-30)
 
 
-### 🐛 Bug Fixes
-
-* **ci:** Add copy removal of sub module ([#12](https://github.com/spotify/confidence-sdk-flutter/issues/12)) ([a756da2](https://github.com/spotify/confidence-sdk-flutter/commit/a756da2c5da4a85deb3f26d3813d50e7bda7a020))
-* **ci:** Create and update the directory of the credentials [WIP]  ([#8](https://github.com/spotify/confidence-sdk-flutter/issues/8)) ([3404b4e](https://github.com/spotify/confidence-sdk-flutter/commit/3404b4e8658ba3d6726ca2b6e1cea9389723dbea))
-* **ci:** Fix pub warnings ([#15](https://github.com/spotify/confidence-sdk-flutter/issues/15)) ([3d9194c](https://github.com/spotify/confidence-sdk-flutter/commit/3d9194c4d9f059d9803ad4f690b8bf6653600d40))
-* **ci:** Fix typo in pub login script ([#6](https://github.com/spotify/confidence-sdk-flutter/issues/6)) ([bdce2da](https://github.com/spotify/confidence-sdk-flutter/commit/bdce2da75b7bb2c21a68a09e012d43184709416f))
-* Current version is 0.0.3 in pub.dev ([#10](https://github.com/spotify/confidence-sdk-flutter/issues/10)) ([963f707](https://github.com/spotify/confidence-sdk-flutter/commit/963f7077ef825284359f03bcea63c849de214083))
-
-
 ### ✨ New Features
 
-* Add flush method ([#19](https://github.com/spotify/confidence-sdk-flutter/issues/19)) ([0299534](https://github.com/spotify/confidence-sdk-flutter/commit/02995341c06e0d5e2343857da6394511d6c26b88))
 * Add non blocking way of getting values ([#24](https://github.com/spotify/confidence-sdk-flutter/issues/24)) ([8b1a163](https://github.com/spotify/confidence-sdk-flutter/commit/8b1a1639c4a66ed2dd33854ff61638f693484df5))
 
-
-### 🧹 Chore
-
-* **main:** release 0.0.4 ([#11](https://github.com/spotify/confidence-sdk-flutter/issues/11)) ([04a7e32](https://github.com/spotify/confidence-sdk-flutter/commit/04a7e328101165ffd4cee04ffe20853d3db4865a))
-* **main:** release 0.0.4 ([#13](https://github.com/spotify/confidence-sdk-flutter/issues/13)) ([7b23d2e](https://github.com/spotify/confidence-sdk-flutter/commit/7b23d2e8f1008322e3e3ba4b54118ed063aaf37d))
-* **main:** release 0.0.4 ([#16](https://github.com/spotify/confidence-sdk-flutter/issues/16)) ([43b4423](https://github.com/spotify/confidence-sdk-flutter/commit/43b4423e88aeb7869c50b2ef3e6155958475004c))
-* **main:** release 0.0.5 ([#17](https://github.com/spotify/confidence-sdk-flutter/issues/17)) ([ad7e91f](https://github.com/spotify/confidence-sdk-flutter/commit/ad7e91f4bbbd55666caca8d0870828ebe6aca986))
-* **main:** release 0.0.6 ([#7](https://github.com/spotify/confidence-sdk-flutter/issues/7)) ([1abe531](https://github.com/spotify/confidence-sdk-flutter/commit/1abe53137d7d0f12951d657f7263b53e1ce54801))
-* **main:** release 0.0.7 ([#9](https://github.com/spotify/confidence-sdk-flutter/issues/9)) ([54fb940](https://github.com/spotify/confidence-sdk-flutter/commit/54fb9406e0f418b70a876f8b4df5e6217fbc499b))
-
-
-### 📚 Documentation
-
-* Add running example app in xcode in readme ([#20](https://github.com/spotify/confidence-sdk-flutter/issues/20)) ([4d0142b](https://github.com/spotify/confidence-sdk-flutter/commit/4d0142b45e58a1f5bb5ae9771a1a40615916ab66))
-* minor corrections ([#18](https://github.com/spotify/confidence-sdk-flutter/issues/18)) ([e02c6d7](https://github.com/spotify/confidence-sdk-flutter/commit/e02c6d720d7c5bf6ece0bfcf39b7f5965aa7acde))
 
 ## [0.0.5](https://github.com/spotify/confidence-sdk-flutter/compare/0.0.4...0.0.5) (2024-07-05)
 
 
-### 🐛 Bug Fixes
-
-* **ci:** Add copy removal of sub module ([#12](https://github.com/spotify/confidence-sdk-flutter/issues/12)) ([a756da2](https://github.com/spotify/confidence-sdk-flutter/commit/a756da2c5da4a85deb3f26d3813d50e7bda7a020))
-* **ci:** Fix pub warnings ([#15](https://github.com/spotify/confidence-sdk-flutter/issues/15)) ([3d9194c](https://github.com/spotify/confidence-sdk-flutter/commit/3d9194c4d9f059d9803ad4f690b8bf6653600d40))
-
-
 ### ✨ New Features
 
 * Add flush method ([#19](https://github.com/spotify/confidence-sdk-flutter/issues/19)) ([0299534](https://github.com/spotify/confidence-sdk-flutter/commit/02995341c06e0d5e2343857da6394511d6c26b88))
-
-
-### 🧹 Chore
-
-* **main:** release 0.0.4 ([#13](https://github.com/spotify/confidence-sdk-flutter/issues/13)) ([7b23d2e](https://github.com/spotify/confidence-sdk-flutter/commit/7b23d2e8f1008322e3e3ba4b54118ed063aaf37d))
-* **main:** release 0.0.4 ([#16](https://github.com/spotify/confidence-sdk-flutter/issues/16)) ([43b4423](https://github.com/spotify/confidence-sdk-flutter/commit/43b4423e88aeb7869c50b2ef3e6155958475004c))
 
 
 ### 📚 Documentation
@@ -112,85 +41,3 @@
 * Add running example app in xcode in readme ([#20](https://github.com/spotify/confidence-sdk-flutter/issues/20)) ([4d0142b](https://github.com/spotify/confidence-sdk-flutter/commit/4d0142b45e58a1f5bb5ae9771a1a40615916ab66))
 * minor corrections ([#18](https://github.com/spotify/confidence-sdk-flutter/issues/18)) ([e02c6d7](https://github.com/spotify/confidence-sdk-flutter/commit/e02c6d720d7c5bf6ece0bfcf39b7f5965aa7acde))
 
-## [0.0.4](https://github.com/spotify/confidence-sdk-flutter/compare/v0.0.3...0.0.4) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Add copy removal of sub module ([#12](https://github.com/spotify/confidence-sdk-flutter/issues/12)) ([a756da2](https://github.com/spotify/confidence-sdk-flutter/commit/a756da2c5da4a85deb3f26d3813d50e7bda7a020))
-* **ci:** Add release please manifest file ([#4](https://github.com/spotify/confidence-sdk-flutter/issues/4)) ([7687ab4](https://github.com/spotify/confidence-sdk-flutter/commit/7687ab4da3151fc70d21beec495762085408a47e))
-* **ci:** Create and update the directory of the credentials [WIP]  ([#8](https://github.com/spotify/confidence-sdk-flutter/issues/8)) ([3404b4e](https://github.com/spotify/confidence-sdk-flutter/commit/3404b4e8658ba3d6726ca2b6e1cea9389723dbea))
-* **ci:** Fix pub warnings ([#15](https://github.com/spotify/confidence-sdk-flutter/issues/15)) ([3d9194c](https://github.com/spotify/confidence-sdk-flutter/commit/3d9194c4d9f059d9803ad4f690b8bf6653600d40))
-* **ci:** Fix typo in pub login script ([#6](https://github.com/spotify/confidence-sdk-flutter/issues/6)) ([bdce2da](https://github.com/spotify/confidence-sdk-flutter/commit/bdce2da75b7bb2c21a68a09e012d43184709416f))
-* Current version is 0.0.3 in pub.dev ([#10](https://github.com/spotify/confidence-sdk-flutter/issues/10)) ([963f707](https://github.com/spotify/confidence-sdk-flutter/commit/963f7077ef825284359f03bcea63c849de214083))
-
-
-### 🧹 Chore
-
-* **main:** release 0.0.4 ([#11](https://github.com/spotify/confidence-sdk-flutter/issues/11)) ([04a7e32](https://github.com/spotify/confidence-sdk-flutter/commit/04a7e328101165ffd4cee04ffe20853d3db4865a))
-* **main:** release 0.0.4 ([#13](https://github.com/spotify/confidence-sdk-flutter/issues/13)) ([7b23d2e](https://github.com/spotify/confidence-sdk-flutter/commit/7b23d2e8f1008322e3e3ba4b54118ed063aaf37d))
-* **main:** release 0.0.5 ([#5](https://github.com/spotify/confidence-sdk-flutter/issues/5)) ([0e04fa0](https://github.com/spotify/confidence-sdk-flutter/commit/0e04fa001089f999e591fba2fac95de0cde65e2c))
-* **main:** release 0.0.6 ([#7](https://github.com/spotify/confidence-sdk-flutter/issues/7)) ([1abe531](https://github.com/spotify/confidence-sdk-flutter/commit/1abe53137d7d0f12951d657f7263b53e1ce54801))
-* **main:** release 0.0.7 ([#9](https://github.com/spotify/confidence-sdk-flutter/issues/9)) ([54fb940](https://github.com/spotify/confidence-sdk-flutter/commit/54fb9406e0f418b70a876f8b4df5e6217fbc499b))
-
-## [0.0.4](https://github.com/spotify/confidence-sdk-flutter/compare/v0.0.3...0.0.4) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Add copy removal of sub module ([#12](https://github.com/spotify/confidence-sdk-flutter/issues/12)) ([a756da2](https://github.com/spotify/confidence-sdk-flutter/commit/a756da2c5da4a85deb3f26d3813d50e7bda7a020))
-* **ci:** Add release please manifest file ([#4](https://github.com/spotify/confidence-sdk-flutter/issues/4)) ([7687ab4](https://github.com/spotify/confidence-sdk-flutter/commit/7687ab4da3151fc70d21beec495762085408a47e))
-* **ci:** Create and update the directory of the credentials [WIP]  ([#8](https://github.com/spotify/confidence-sdk-flutter/issues/8)) ([3404b4e](https://github.com/spotify/confidence-sdk-flutter/commit/3404b4e8658ba3d6726ca2b6e1cea9389723dbea))
-* **ci:** Fix typo in pub login script ([#6](https://github.com/spotify/confidence-sdk-flutter/issues/6)) ([bdce2da](https://github.com/spotify/confidence-sdk-flutter/commit/bdce2da75b7bb2c21a68a09e012d43184709416f))
-* Current version is 0.0.3 in pub.dev ([#10](https://github.com/spotify/confidence-sdk-flutter/issues/10)) ([963f707](https://github.com/spotify/confidence-sdk-flutter/commit/963f7077ef825284359f03bcea63c849de214083))
-
-
-### 🧹 Chore
-
-* **main:** release 0.0.4 ([#11](https://github.com/spotify/confidence-sdk-flutter/issues/11)) ([04a7e32](https://github.com/spotify/confidence-sdk-flutter/commit/04a7e328101165ffd4cee04ffe20853d3db4865a))
-* **main:** release 0.0.5 ([#5](https://github.com/spotify/confidence-sdk-flutter/issues/5)) ([0e04fa0](https://github.com/spotify/confidence-sdk-flutter/commit/0e04fa001089f999e591fba2fac95de0cde65e2c))
-* **main:** release 0.0.6 ([#7](https://github.com/spotify/confidence-sdk-flutter/issues/7)) ([1abe531](https://github.com/spotify/confidence-sdk-flutter/commit/1abe53137d7d0f12951d657f7263b53e1ce54801))
-* **main:** release 0.0.7 ([#9](https://github.com/spotify/confidence-sdk-flutter/issues/9)) ([54fb940](https://github.com/spotify/confidence-sdk-flutter/commit/54fb9406e0f418b70a876f8b4df5e6217fbc499b))
-
-## [0.0.4](https://github.com/spotify/confidence-sdk-flutter/compare/v0.0.3...0.0.4) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Add release please manifest file ([#4](https://github.com/spotify/confidence-sdk-flutter/issues/4)) ([7687ab4](https://github.com/spotify/confidence-sdk-flutter/commit/7687ab4da3151fc70d21beec495762085408a47e))
-* **ci:** Create and update the directory of the credentials [WIP]  ([#8](https://github.com/spotify/confidence-sdk-flutter/issues/8)) ([3404b4e](https://github.com/spotify/confidence-sdk-flutter/commit/3404b4e8658ba3d6726ca2b6e1cea9389723dbea))
-* **ci:** Fix typo in pub login script ([#6](https://github.com/spotify/confidence-sdk-flutter/issues/6)) ([bdce2da](https://github.com/spotify/confidence-sdk-flutter/commit/bdce2da75b7bb2c21a68a09e012d43184709416f))
-* Current version is 0.0.3 in pub.dev ([#10](https://github.com/spotify/confidence-sdk-flutter/issues/10)) ([963f707](https://github.com/spotify/confidence-sdk-flutter/commit/963f7077ef825284359f03bcea63c849de214083))
-
-
-### 🧹 Chore
-
-* **main:** release 0.0.5 ([#5](https://github.com/spotify/confidence-sdk-flutter/issues/5)) ([0e04fa0](https://github.com/spotify/confidence-sdk-flutter/commit/0e04fa001089f999e591fba2fac95de0cde65e2c))
-* **main:** release 0.0.6 ([#7](https://github.com/spotify/confidence-sdk-flutter/issues/7)) ([1abe531](https://github.com/spotify/confidence-sdk-flutter/commit/1abe53137d7d0f12951d657f7263b53e1ce54801))
-* **main:** release 0.0.7 ([#9](https://github.com/spotify/confidence-sdk-flutter/issues/9)) ([54fb940](https://github.com/spotify/confidence-sdk-flutter/commit/54fb9406e0f418b70a876f8b4df5e6217fbc499b))
-
-## [0.0.7](https://github.com/spotify/confidence-sdk-flutter/compare/0.0.6...0.0.7) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Create and update the directory of the credentials [WIP]  ([#8](https://github.com/spotify/confidence-sdk-flutter/issues/8)) ([3404b4e](https://github.com/spotify/confidence-sdk-flutter/commit/3404b4e8658ba3d6726ca2b6e1cea9389723dbea))
-
-## [0.0.6](https://github.com/spotify/confidence-sdk-flutter/compare/0.0.5...0.0.6) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Fix typo in pub login script ([#6](https://github.com/spotify/confidence-sdk-flutter/issues/6)) ([bdce2da](https://github.com/spotify/confidence-sdk-flutter/commit/bdce2da75b7bb2c21a68a09e012d43184709416f))
-
-## [0.0.5](https://github.com/spotify/confidence-sdk-flutter/compare/v0.0.4...0.0.5) (2024-07-03)
-
-
-### 🐛 Bug Fixes
-
-* **ci:** Add release please manifest file ([#4](https://github.com/spotify/confidence-sdk-flutter/issues/4)) ([7687ab4](https://github.com/spotify/confidence-sdk-flutter/commit/7687ab4da3151fc70d21beec495762085408a47e))
-
-## 0.0.1
-
-Add resolving flags from the confidence sdk.
-Send custom events from the confidence sdk.


### PR DESCRIPTION
A mishap with the release-please tooling caused us to have a bunch of invalid tags which made the release notes and changelog misbehave.