### PR TITLE
feat: drop ludwigs-new-test-flag, use hawkflag.message

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -57,7 +57,7 @@ class _MyAppState extends State<MyApp> {
       object =
       (_confidenceFlutterSdkPlugin.getObject("hawkflag", <String, dynamic>{})).toString();
       message =
-          (_confidenceFlutterSdkPlugin.getString("ludwigs-new-test-flag.struct-key.string-key", "0"));
+          (_confidenceFlutterSdkPlugin.getString("hawkflag.message", ""));
       final data = {
         'screen': 'home',
         "my_bool": false,

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -18,7 +18,7 @@ void main() {
       if(count == 0) {
         final textWidget = element.widget as Text;
         final string = textWidget.data?.trim() ?? "";
-        expect(string, "1337");
+        expect(["Goodbye", "Welcome"].contains(string), true);
       }
       if(count == 1) {
         final textWidget = element.widget as Text;


### PR DESCRIPTION
## Summary
- Replace `ludwigs-new-test-flag.struct-key.string-key` with `hawkflag.message` in example app
- Update widget test to expect hawkflag message values (`"Goodbye"` or `"Welcome"`)
- Migrates to new Confidence workspace — `TEST_API_KEY` secret already updated

## Test plan
- [ ] Android e2e test passes (emulator)
- [ ] iOS e2e test passes (simulator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)