### PR TITLE
fix: target ListTile descendants in integration test

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:confidence_flutter_sdk_example/main.dart';
 import 'package:integration_test/integration_test.dart';
@@ -12,22 +12,15 @@ void main() {
     await myApp.initDone();
     // expect a list item with text evaluation exist
     await tester.pump();
-    final textWidgets = find.byType(Text);
-    int count = 0;
-    textWidgets.evaluate().forEach((element) {
-      if(count == 0) {
-        final textWidget = element.widget as Text;
-        final string = textWidget.data?.trim() ?? "";
-        expect(["Goodbye", "Welcome"].contains(string), true);
-      }
-      if(count == 1) {
-        final textWidget = element.widget as Text;
-        final string = textWidget.data?.trim() ?? "";
-        expect(string.contains("enabled"), true);
-        expect(string.contains("message"), true);
-        expect(string.contains("color"), true);
-      }
-      count++;
-    });
+    final listTiles = find.byType(ListTile);
+    expect(listTiles, findsNWidgets(2));
+
+    final messageText = (find.descendant(of: listTiles.at(0), matching: find.byType(Text)).evaluate().first.widget as Text).data?.trim() ?? "";
+    expect(["Goodbye", "Welcome"].contains(messageText), true);
+
+    final objectText = (find.descendant(of: listTiles.at(1), matching: find.byType(Text)).evaluate().first.widget as Text).data?.trim() ?? "";
+    expect(objectText.contains("enabled"), true);
+    expect(objectText.contains("message"), true);
+    expect(objectText.contains("color"), true);
 });
 }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -11,7 +11,7 @@ void main() {
     await tester.pumpWidget(myApp);
     await myApp.initDone();
     // expect a list item with text evaluation exist
-    await tester.pump();
+    await tester.pumpAndSettle();
     final listTiles = find.byType(ListTile);
     expect(listTiles, findsNWidgets(2));
 


### PR DESCRIPTION
## Summary
- Integration test was flaky because `find.byType(Text)` could pick up the AppBar title at index 0 instead of the flag value, depending on widget tree traversal order.
- Now uses `find.descendant` scoped to `ListTile` widgets, so only the actual data texts are asserted on.

## Test plan
- [ ] CI Test-Android passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)