### PR TITLE
fix: drop git-add step that caused pub dry-run to fail

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -55,9 +55,6 @@ jobs:
         working-directory: ios/Classes
         run: rm -rf confidence-sdk && git rm -r --cached .
 
-      - name: Stage copied sources for pub
-        run: git add ios/Classes/Confidence ios/confidence_flutter_sdk/Sources/confidence_flutter_sdk/Confidence
-      
       - name: Setup Pub Credentials
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- Remove `git add` step from release workflow — staging the copied Confidence sources caused `flutter pub publish --dry-run` to fail with "112 checked-in files are modified in git" (exit code 65)
- Pub packages from the filesystem and the copied sources aren't gitignored, so they're included without staging

## Test plan
- [ ] Trigger a release and confirm `flutter pub publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)